### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/lib/recoverable_stream.ex
+++ b/lib/recoverable_stream.ex
@@ -103,7 +103,7 @@ defmodule RecoverableStream do
 
      See `RecoverableStream.TasksPool.child_spec/1` for details.
 
-  - `:wrapper_fun` is a funciton that wraps a stream reducer running
+  - `:wrapper_fun` is a function that wraps a stream reducer running
      inside a `Task` (defaults to `fun f -> f.(%{}) end`).
 
      Useful when the `t:stream_fun/0` must be run within a certain


### PR DESCRIPTION
I "accidentally" spotted a typo while reading the docs, here is the fix.